### PR TITLE
use vendored reveal.js

### DIFF
--- a/.github/workflows/pandoc-gh-pages.yml
+++ b/.github/workflows/pandoc-gh-pages.yml
@@ -29,9 +29,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Download reveal.js
         run: |
+          mkdir _site
           wget https://github.com/hakimel/reveal.js/archive/master.zip
           unzip master.zip
-          mv reveal.js-master _site
+          mv reveal.js-master _site/revealjs
       - name: Build with pandoc
         uses: docker://pandoc/core:latest
         with:
@@ -40,6 +41,7 @@ jobs:
             --standalone
             --output=_site/index.html
             --include-in-header=slides.css
+            -V revealjs-url=./revealjs
             esperanto-kurseto.md
       - name: Copy images
         run: cp -r images _site


### PR DESCRIPTION
Currently, even though https://c3esperanto.github.io/kurseto/ includes a copy of reveal.js (with its files and directories directly in the `kurseto` root directory, https://c3esperanto.github.io/kurseto/package.json), it doesn't use it and instead loads reveal.js from `https://unpkg.com/reveal.js@^4/` (Pandoc's default for variable `revealjs-url`).

This change makes it use the vendored (included) reveal.js by setting said variable to a path-relative URL. It also packs reveal.js neatly into a sub-directory, so that it doesn't uncontrollably mix with the file(s) generated by Pandoc.

Currently, this change can be previewed at https://das-g.github.io/c3-esperanto-kurseto/