### PR TITLE
fix formatting of «into»

### DIFF
--- a/esperanto-kurseto.md
+++ b/esperanto-kurseto.md
@@ -132,7 +132,7 @@ Marks the direct object. Examples:
 Can also do other things, e.g. indicate direction instead of location:
 
 * Mi dancas en la dancejo. — I am dancing in the dancing room.
-* Mi dancas en la dancejon. — I am dancing *into** the dancing room.
+* Mi dancas en la dancejon. — I am dancing **into** the dancing room.
 
 
 ## Esperanto avoids ambiguities


### PR DESCRIPTION
In the markdown source, there's currently an inconsistent number of `*`s around the word «into». This causes it to be rendered as

> \*into\*\*

at https://c3esperanto.github.io/kurseto/#/accusative

I don't know whether *(standard) emphasis* (italics) or **strong emphasis** (bold) was intended here and opted for strong emphasis.