### PR TITLE
fix translation of correlative (tabelvorto) "ĉiel"

### DIFF
--- a/esperanto-kurseto.md
+++ b/esperanto-kurseto.md
@@ -194,7 +194,7 @@ Hamburgo estas grandega urbo. – Püttlingen estas malgranda urbo.
 | iom | *how much*  | kiom | tiom | ĉiom  | neniom |
 | ies | *whose*     | kies | ties | ĉies  | nenies |
 
-ĉio – everything · nenie – nowhere · ĉiel – in any way · iel – somehow
+ĉio – everything · nenie – nowhere · ĉiel – in every way · iel – somehow
 
 ## Some important "small" words
 


### PR DESCRIPTION
"ĉiel" means "in **every** way", not "in any way".